### PR TITLE
added powerfx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this extension will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+## [0.3.0] - 2024-06-28
+### Added
+- Support for Power Fx 
+
 ## [0.2.0] - 2023-07-29
 ### Added
 - Issue [#9](https://github.com/harrydowning/yaml-embedded-languages/issues/9)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [Unreleased]
 ## [0.3.0] - 2024-06-28
 ### Added
-- Support for Power Fx 
+- Support for Power Fx (Issue [#17])
 
 ## [0.2.0] - 2023-07-29
 ### Added

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The following list shows all valid identifiers for the built-in languages:
 - objc
 - perl
 - pip or requirements
+- powerfx
 - powershell
 - properties
 - python or py

--- a/extension.js
+++ b/extension.js
@@ -3,7 +3,7 @@ const vscode = devFlag ? null : require('vscode');
 const fs = require('fs');
 
 const NAME = "yaml-embedded-languages";
-const VERSION = "0.2.0";
+const VERSION = "0.3.0";
 const DISPLAY_NAME = "YAML Embedded Languages";
 const INJECTION_PATH = "./syntaxes/injection.json";
 const SCOPE_NAME = `${NAME}.injection`;

--- a/extension.js
+++ b/extension.js
@@ -36,6 +36,7 @@ const LANGUAGES = {
   "objc": "source.objc",
   "perl": "source.perl",
   "pip|requirements": "source.pip-requirements",
+  "powerfx": "source.js",
   "powershell": "source.powershell",
   "properties": "source.properties",
   "python|py": "source.python",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,16 @@
+{
+  "name": "yaml-embedded-languages",
+  "version": "0.2.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "yaml-embedded-languages",
+      "version": "0.2.0",
+      "license": "MIT",
+      "engines": {
+        "vscode": "^1.74.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
           "meta.embedded.inline.objc": "objc",
           "meta.embedded.inline.perl": "perl",
           "meta.embedded.inline.pip|requirements": "pip|requirements",
+          "meta.embedded.inline.powerfx": "powerfx",
           "meta.embedded.inline.powershell": "powershell",
           "meta.embedded.inline.properties": "properties",
           "meta.embedded.inline.python|py": "python|py",

--- a/syntaxes/injection.json
+++ b/syntaxes/injection.json
@@ -72,6 +72,9 @@
       "include": "#pip|requirements-block-scalar"
     },
     {
+      "include": "#powerfx-block-scalar"
+    },
+    {
       "include": "#powershell-block-scalar"
     },
     {
@@ -1131,6 +1134,50 @@
           "patterns": [
             {
               "include": "source.pip-requirements"
+            }
+          ]
+        }
+      ]
+    },
+    "powerfx-block-scalar": {
+      "begin": "(?i)(?:(\\|)|(>))([1-9])?([-+])?[ \t]+(#[ \t]*(?:powerfx)[ \t]*\\n)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.flow.block-scalar.literal.yaml"
+        },
+        "2": {
+          "name": "keyword.control.flow.block-scalar.folded.yaml"
+        },
+        "3": {
+          "name": "constant.numeric.indentation-indicator.yaml"
+        },
+        "4": {
+          "name": "storage.modifier.chomping-indicator.yaml"
+        },
+        "5": {
+          "patterns": [
+            {
+              "begin": "#",
+              "beginCaptures": {
+                "0": {
+                  "name": "punctuation.definition.comment.yaml"
+                }
+              },
+              "end": "\\n"
+            }
+          ],
+          "name": "comment.line.number-sign.yaml"
+        }
+      },
+      "end": "^(?=\\S)|(?!\\G)",
+      "patterns": [
+        {
+          "begin": "^([ ]+)(?! )",
+          "end": "^(?!\\1|\\s*$)",
+          "name": "meta.embedded.inline.powerfx",
+          "patterns": [
+            {
+              "include": "source.js"
             }
           ]
         }


### PR DESCRIPTION
Closes #17 

Turns out `# javascript` does a good job of syntax highlighting for Power Fx.  
![image](https://github.com/harrydowning/yaml-embedded-languages/assets/4499296/adec7c07-eab0-4024-b1c2-82e5b27a427b)
In order to support `# powerfx` through this extension, I added `powerfx` but just use the same syntax highlighting as `javascript`.  The result looks like.
![image](https://github.com/harrydowning/yaml-embedded-languages/assets/4499296/f2fed556-2a62-4cf8-9e8a-4fa7b9f57d99)
As I find any nuances that warrant Power Fx specific formatting, I can contribute more.  But, for now, this seemed to do the trick.