### PR TITLE
feat: Only update extension files on version update [release]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+## [0.3.3] - 2024-07-06
+
+### Changed
+
+- Only update extension files on version update
+
 ## [0.3.2] - 2024-07-06
 
 ### Fixed
@@ -60,7 +66,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - Highlighting support for 40 languages in YAML block-scalars
 
-[unreleased]: https://github.com/harrydowning/yaml-embedded-languages/compare/v0.3.2...HEAD
+[unreleased]: https://github.com/harrydowning/yaml-embedded-languages/compare/v0.3.3...HEAD
+[0.3.3]: https://github.com/harrydowning/yaml-embedded-languages/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/harrydowning/yaml-embedded-languages/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/harrydowning/yaml-embedded-languages/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/harrydowning/yaml-embedded-languages/compare/v0.2.0...v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Changed
 
 - Only update extension files on version update
+- Doc formatting and links
 
 ## [0.3.2] - 2024-07-06
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,20 +2,20 @@
 
 Thank you for taking an interest in contributing to this project. All contributions are welcome. Please find below the suggested contribution, development, and release workflows.
 
-## Contribution Workflow [#](#contribution-workflow- "Contribution Workflow")
+## Contribution Workflow
 
 - Raise/find an [issue](https://github.com/harrydowning/yaml-embedded-languages/issues) to fix
 - Fork the repository
 - Implement changes (see [development workflow](#development-workflow-))
 - Create pull request
 
-## Development Workflow [#](#development-workflow- "Development Workflow")
+## Development Workflow
 
 - Implement changes, ensuring any to `package.json` or `syntaxes/injection.json` are reflected in `extension.js`
 - Run `node extension.js -dev` to update `package.json` and `syntaxes/injection.json`
 - Use F5 within Vs Code to test the extension
 
-## Release Workflow [#](#release-workflow- "Release Workflow")
+## Release Workflow
 
 - Update `VERSION` in `extension.js` and run `node extension.js -dev`
 - Update `CHANGELOG.md`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for taking an interest in contributing to this project. All contributi
 
 - Raise/find an [issue](https://github.com/harrydowning/yaml-embedded-languages/issues) to fix
 - Fork the repository
-- Implement changes (see [development workflow](#development-workflow-))
+- Implement changes (see [development workflow](#development-workflow))
 - Create pull request
 
 ## Development Workflow

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 ![GitHub](https://img.shields.io/github/license/harrydowning/yaml-embedded-languages?color=forest) ![Visual Studio Marketplace Version (including pre-releases)](https://img.shields.io/visual-studio-marketplace/v/harrydowning.yaml-embedded-languages?color=red) ![Visual Studio Marketplace Downloads](https://img.shields.io/visual-studio-marketplace/d/harrydowning.yaml-embedded-languages?color=rebeccapurple)
 
-## Features [#](#features- 'Features')
+## Features
 
 Syntax highlighting within YAML block-scalars for [40+ built-in languages](#built-in-languages- 'Built-In Languages') and the ability to add highlighting for any other language with the [yaml-embedded-languages.include](#extension-settings- 'Extension Settings') configuration setting.
 
 ![Example yaml file showing syntax highlighting](https://raw.githubusercontent.com/harrydowning/yaml-embedded-languages/master/images/example.png)
 
-### Built-In Languages [#](#built-in-languages- 'Built-In Languages')
+### Built-In Languages
 The following list shows all valid identifiers for the built-in languages:
 - c
 - clojure
@@ -52,25 +52,25 @@ The following list shows all valid identifiers for the built-in languages:
 - xml
 - yaml (Yes, YAML within YAML!)
 
-## Requirements [#](#requirements- 'Requirements')
+## Requirements
 
 None
 
-## Extension Settings [#](#extension-settings- 'Extension Settings')
+## Extension Settings
 
 | Name | Description |
 | ---- | ----------- |
 | `yaml-embedded-languages.include` | Allows the user to include their own languages by providing an object where each key defines the language identifier with regex and the corresponding value specifies the language TextMate `scopeName`. This can be used to add any other language, which could be from another extension. This also allows the user to override any language identifiers currently used for the built-in languages. |
 
-## Known Issues [#](#known-issues- 'Known Issues')
+## Known Issues
 
 See [Issues](https://github.com/harrydowning/yaml-embedded-languages/issues)
 
 
-## Contribution Notes [#](#contribution-notes- 'Contribution Notes')
+## Contribution Notes
 
 See [CONTRIBUTING](CONTRIBUTING.md)
 
-## Release Notes [#](#release-notes- 'Release Notes')
+## Release Notes
 
 See [CHANGELOG](CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
+<div align="center">
+
 # YAML Embedded Languages
 
-![GitHub](https://img.shields.io/github/license/harrydowning/yaml-embedded-languages?color=forest) ![Visual Studio Marketplace Version (including pre-releases)](https://img.shields.io/visual-studio-marketplace/v/harrydowning.yaml-embedded-languages?color=red) ![Visual Studio Marketplace Downloads](https://img.shields.io/visual-studio-marketplace/d/harrydowning.yaml-embedded-languages?color=rebeccapurple)
+![GitHub License](https://img.shields.io/github/license/harrydowning/yaml-embedded-languages?style=for-the-badge)
+![Visual Studio Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/harrydowning.yaml-embedded-languages?style=for-the-badge)
+![Visual Studio Marketplace Downloads](https://img.shields.io/visual-studio-marketplace/d/harrydowning.yaml-embedded-languages?style=for-the-badge)
+
+</div>
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@
 
 ## Features
 
-Syntax highlighting within YAML block-scalars for [40+ built-in languages](#built-in-languages- 'Built-In Languages') and the ability to add highlighting for any other language with the [yaml-embedded-languages.include](#extension-settings- 'Extension Settings') configuration setting.
+Syntax highlighting within YAML block-scalars for [40+ built-in languages](#built-in-languages- "Built-In Languages") and the ability to add highlighting for any other language with the [yaml-embedded-languages.include](#extension-settings- "Extension Settings") configuration setting.
 
 ![Example yaml file showing syntax highlighting](https://raw.githubusercontent.com/harrydowning/yaml-embedded-languages/master/images/example.png)
 
 ### Built-In Languages
+
 The following list shows all valid identifiers for the built-in languages:
+
 - c
 - clojure
 - coffee
@@ -58,14 +60,13 @@ None
 
 ## Extension Settings
 
-| Name | Description |
-| ---- | ----------- |
+| Name                              | Description                                                                                                                                                                                                                                                                                                                                                                                           |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `yaml-embedded-languages.include` | Allows the user to include their own languages by providing an object where each key defines the language identifier with regex and the corresponding value specifies the language TextMate `scopeName`. This can be used to add any other language, which could be from another extension. This also allows the user to override any language identifiers currently used for the built-in languages. |
 
 ## Known Issues
 
 See [Issues](https://github.com/harrydowning/yaml-embedded-languages/issues)
-
 
 ## Contribution Notes
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![GitHub License](https://img.shields.io/github/license/harrydowning/yaml-embedded-languages?style=for-the-badge)
 ![Visual Studio Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/harrydowning.yaml-embedded-languages?style=for-the-badge)
-![Visual Studio Marketplace Downloads](https://img.shields.io/visual-studio-marketplace/d/harrydowning.yaml-embedded-languages?style=for-the-badge)
+![Visual Studio Marketplace Downloads](https://img.shields.io/visual-studio-marketplace/d/harrydowning.yaml-embedded-languages?style=for-the-badge&color=rebeccapurple)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Features
 
-Syntax highlighting within YAML block-scalars for [40+ built-in languages](#built-in-languages- "Built-In Languages") and the ability to add highlighting for any other language with the [yaml-embedded-languages.include](#extension-settings- "Extension Settings") configuration setting.
+Syntax highlighting within YAML block-scalars for [40+ built-in languages](#built-in-languages "Built-In Languages") and the ability to add highlighting for any other language with the [yaml-embedded-languages.include](#extension-settings "Extension Settings") configuration setting.
 
 ![Example yaml file showing syntax highlighting](https://raw.githubusercontent.com/harrydowning/yaml-embedded-languages/master/images/example.png)
 

--- a/extension.js
+++ b/extension.js
@@ -5,12 +5,14 @@ const fs = require("fs");
 const NAME = "yaml-embedded-languages";
 const VERSION = "0.3.2";
 const DISPLAY_NAME = "YAML Embedded Languages";
+const PUBLISHER = "harrydowning";
 const INJECTION_PATH = "./syntaxes/injection.json";
 const SCOPE_NAME = `${NAME}.injection`;
 const SUB_INCLUDE_CONFIG = "include";
 const INCLUDE_CONFIG = `${NAME}.${SUB_INCLUDE_CONFIG}`;
 const LANGUAGE_SCOPE_PREFIX = "meta.embedded.inline";
 const REPOSITORY_SUFFIX = "block-scalar";
+const GLOBAL_STATE_VERSION = "version";
 
 const LANGUAGES = {
   c: "source.c",
@@ -75,7 +77,7 @@ const getPackageJson = (languages) => ({
   displayName: DISPLAY_NAME,
   description: "Support for syntax highlighting within YAML block-scalars.",
   icon: "images/icon.png",
-  publisher: "harrydowning",
+  publisher: PUBLISHER,
   author: {
     name: "Harry Downing",
     email: "harry.downing17@gmail.com",
@@ -131,7 +133,7 @@ const getPatterns = (languages) => {
 };
 
 const getRepository = (languages) => {
-  entries = Object.entries(languages);
+  const entries = Object.entries(languages);
   return Object.fromEntries(
     entries.map(([name, scopeName]) => [
       `${name}-${REPOSITORY_SUFFIX}`,
@@ -231,7 +233,14 @@ const updateExtension = () => {
 };
 
 const activate = (context) => {
-  updateExtension();
+  const extension = vscode.extensions.getExtension(`${PUBLISHER}.${NAME}`);
+  const currentVersion = extension.packageJSON.version;
+  const previousVersion = context.globalState.get(GLOBAL_STATE_VERSION);
+
+  if (previousVersion !== currentVersion) {
+    updateExtension();
+    context.globalState.update(GLOBAL_STATE_VERSION, currentVersion);
+  }
 
   let disposable = vscode.workspace.onDidChangeConfiguration((event) => {
     if (event.affectsConfiguration(INCLUDE_CONFIG)) {

--- a/extension.js
+++ b/extension.js
@@ -3,7 +3,7 @@ const vscode = DEV_MODE ? null : require("vscode");
 const fs = require("fs");
 
 const NAME = "yaml-embedded-languages";
-const VERSION = "0.3.2";
+const VERSION = "0.3.3";
 const DISPLAY_NAME = "YAML Embedded Languages";
 const PUBLISHER = "harrydowning";
 const INJECTION_PATH = "./syntaxes/injection.json";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yaml-embedded-languages",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yaml-embedded-languages",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "devDependencies": {
         "@vscode/vsce": "^2.29.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yaml-embedded-languages",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "displayName": "YAML Embedded Languages",
   "description": "Support for syntax highlighting within YAML block-scalars.",
   "icon": "images/icon.png",


### PR DESCRIPTION
To avoid requiring a file read on every activation, only update extension files when the extension is updated.