### PR TITLE
Fix embedding in new YAML grammar

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -168,7 +168,7 @@ const getRepository = (languages) => {
         end: "^(?=\\S)|(?!\\G)",
         patterns: [
           {
-            begin: "^([ ]+)(?! )",
+            begin: "(?>^|\\G)([ ]+)(?! )",
             end: "^(?!\\1|\\s*$)",
             name: `${LANGUAGE_SCOPE_PREFIX}.${name}`,
             patterns: [{ include: scopeName }],


### PR DESCRIPTION
VSCode is adopting a new YAML [grammar](https://github.com/microsoft/vscode/issues/180523)
https://github.com/microsoft/vscode/issues/224978

Injecting into nested block maps doesn't work fully anymore
this is because the new grammar captures the prefixing whitespace, disallowing this injection to capture the newline `^`

Workaround is to change `^` to `(^|\\G)`
https://github.com/harrydowning/yaml-embedded-languages/blob/c8478003b71af928fae1496b9600c32bab9fe18e/extension.js#L171


![image](https://github.com/user-attachments/assets/afbc80c1-d5ea-4b82-a4f6-075fa82e0ccd)

![image](https://github.com/user-attachments/assets/95b4901d-c3b9-442a-a9c0-8a50dd2ca39b) ![image](https://github.com/user-attachments/assets/60a7aa0c-a5a2-4005-9417-8cb6dfc6fdda)
