### PR TITLE
fix: Markdown indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Changed
 
-- Partially generate `package.json`
+- Fully generated `package.json` to be partially generated
 
 ## [0.4.0] - 2024-08-18
 
@@ -26,13 +26,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 
-- Correct language names ([#12](https://github.com/harrydowning/yaml-embedded-languages/issues/12))
+- Built-in language names ([#12](https://github.com/harrydowning/yaml-embedded-languages/issues/12))
 
 ## [0.3.3] - 2024-07-06
 
 ### Changed
 
-- Only update extension files on version update
+- Extension to generate files on update
 - Doc formatting and links
 
 ## [0.3.2] - 2024-07-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Fixed
 
 - Markdown indentation ([#13](https://github.com/harrydowning/yaml-embedded-languages/issues/13))
+- Highlighting for new YAML grammar
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,27 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- `stripIndent` language config option
+
+### Fixed
+
+- Markdown indentation ([#13](https://github.com/harrydowning/yaml-embedded-languages/issues/13))
+
+### Changed
+
+- Partially generate `package.json`
+
 ## [0.4.0] - 2024-08-18
 
 ### Added
 
-- Option to specify language name in `yaml-embedded-languages.include` config.
+- Option to specify language name in `yaml-embedded-languages.include` config
 
 ### Fixed
 
-- Correct language names (Issue [#12](https://github.com/harrydowning/yaml-embedded-languages/issues/12))
+- Correct language names ([#12](https://github.com/harrydowning/yaml-embedded-languages/issues/12))
 
 ## [0.3.3] - 2024-07-06
 
@@ -27,7 +39,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 
-- User languages reset on extension update (Issue [#24](https://github.com/harrydowning/yaml-embedded-languages/issues/24))
+- User languages reset on extension update ([#24](https://github.com/harrydowning/yaml-embedded-languages/issues/24))
 - User language override precedence
 
 ## [0.3.1] - 2024-06-29
@@ -40,19 +52,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Added
 
-- Support for Power Fx (Issue [#17](https://github.com/harrydowning/yaml-embedded-languages/issues/17))
+- Support for Power Fx ([#17](https://github.com/harrydowning/yaml-embedded-languages/issues/17))
 
 ## [0.2.0] - 2023-07-29
 
 ### Added
 
-- Issue [#9](https://github.com/harrydowning/yaml-embedded-languages/issues/9)
+- Support for GitHub Actions ([#9](https://github.com/harrydowning/yaml-embedded-languages/issues/9))
 - `CONTRIBUTING.md` documentation
 - `-dev` flag on `extension.js`
 
 ### Fixed
 
-- Issue [#7](https://github.com/harrydowning/yaml-embedded-languages/issues/7)
+- Path separators on macOS ([#7](https://github.com/harrydowning/yaml-embedded-languages/issues/7))
 
 ### Changed
 

--- a/extension.js
+++ b/extension.js
@@ -184,6 +184,7 @@ const getRepository = (languages) => {
           {
             begin: "^([ ]+)(?! )",
             end: "^(?!\\1|\\s*$)",
+            while: "\\1",
             name: `${LANGUAGE_SCOPE_PREFIX}.${id}`,
             patterns: [{ include: scopeName }],
           },

--- a/syntaxes/injection.json
+++ b/syntaxes/injection.json
@@ -180,7 +180,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.c",
           "patterns": [
             {
@@ -225,7 +224,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.clojure",
           "patterns": [
             {
@@ -270,7 +268,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.coffee",
           "patterns": [
             {
@@ -315,7 +312,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.cpp",
           "patterns": [
             {
@@ -360,7 +356,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.c\\+\\+",
           "patterns": [
             {
@@ -405,7 +400,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.csharp",
           "patterns": [
             {
@@ -450,7 +444,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.css",
           "patterns": [
             {
@@ -495,7 +488,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.diff",
           "patterns": [
             {
@@ -540,7 +532,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.dockerfile",
           "patterns": [
             {
@@ -585,7 +576,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.dosbatch",
           "patterns": [
             {
@@ -630,7 +620,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.fsharp",
           "patterns": [
             {
@@ -675,7 +664,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.go",
           "patterns": [
             {
@@ -720,7 +708,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.groovy",
           "patterns": [
             {
@@ -765,7 +752,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.html",
           "patterns": [
             {
@@ -810,7 +796,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.java",
           "patterns": [
             {
@@ -855,7 +840,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.javascript",
           "patterns": [
             {
@@ -900,7 +884,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.js",
           "patterns": [
             {
@@ -945,7 +928,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.json",
           "patterns": [
             {
@@ -990,7 +972,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.tex",
           "patterns": [
             {
@@ -1035,7 +1016,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.latex",
           "patterns": [
             {
@@ -1080,7 +1060,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.lua",
           "patterns": [
             {
@@ -1125,7 +1104,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.makefile",
           "patterns": [
             {
@@ -1215,7 +1193,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.objc",
           "patterns": [
             {
@@ -1260,7 +1237,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.perl",
           "patterns": [
             {
@@ -1305,7 +1281,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.pip",
           "patterns": [
             {
@@ -1350,7 +1325,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.requirements",
           "patterns": [
             {
@@ -1395,7 +1369,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.powerfx",
           "patterns": [
             {
@@ -1440,7 +1413,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.powershell",
           "patterns": [
             {
@@ -1485,7 +1457,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.properties",
           "patterns": [
             {
@@ -1530,7 +1501,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.python",
           "patterns": [
             {
@@ -1575,7 +1545,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.py",
           "patterns": [
             {
@@ -1620,7 +1589,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.r",
           "patterns": [
             {
@@ -1665,7 +1633,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.regex",
           "patterns": [
             {
@@ -1710,7 +1677,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.ruby",
           "patterns": [
             {
@@ -1755,7 +1721,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.rust",
           "patterns": [
             {
@@ -1800,7 +1765,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.scss",
           "patterns": [
             {
@@ -1845,7 +1809,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.shaderlab",
           "patterns": [
             {
@@ -1890,7 +1853,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.shell",
           "patterns": [
             {
@@ -1935,7 +1897,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.slim",
           "patterns": [
             {
@@ -1980,7 +1941,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.sql",
           "patterns": [
             {
@@ -2025,7 +1985,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.swift",
           "patterns": [
             {
@@ -2070,7 +2029,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.typescript",
           "patterns": [
             {
@@ -2115,7 +2073,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.ts",
           "patterns": [
             {
@@ -2160,7 +2117,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.tsx",
           "patterns": [
             {
@@ -2205,7 +2161,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.xml",
           "patterns": [
             {
@@ -2250,7 +2205,6 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
-          "while": "\\1",
           "name": "meta.embedded.inline.yaml",
           "patterns": [
             {

--- a/syntaxes/injection.json
+++ b/syntaxes/injection.json
@@ -178,7 +178,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.c",
           "patterns": [
@@ -222,7 +222,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.clojure",
           "patterns": [
@@ -266,7 +266,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.coffee",
           "patterns": [
@@ -310,7 +310,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.cpp",
           "patterns": [
@@ -354,7 +354,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.c\\+\\+",
           "patterns": [
@@ -398,7 +398,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.csharp",
           "patterns": [
@@ -442,7 +442,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.css",
           "patterns": [
@@ -486,7 +486,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.diff",
           "patterns": [
@@ -530,7 +530,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.dockerfile",
           "patterns": [
@@ -574,7 +574,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.dosbatch",
           "patterns": [
@@ -618,7 +618,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.fsharp",
           "patterns": [
@@ -662,7 +662,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.go",
           "patterns": [
@@ -706,7 +706,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.groovy",
           "patterns": [
@@ -750,7 +750,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.html",
           "patterns": [
@@ -794,7 +794,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.java",
           "patterns": [
@@ -838,7 +838,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.javascript",
           "patterns": [
@@ -882,7 +882,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.js",
           "patterns": [
@@ -926,7 +926,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.json",
           "patterns": [
@@ -970,7 +970,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.tex",
           "patterns": [
@@ -1014,7 +1014,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.latex",
           "patterns": [
@@ -1058,7 +1058,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.lua",
           "patterns": [
@@ -1102,7 +1102,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.makefile",
           "patterns": [
@@ -1146,7 +1146,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "while": "\\1",
           "name": "meta.embedded.inline.markdown",
@@ -1191,7 +1191,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.objc",
           "patterns": [
@@ -1235,7 +1235,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.perl",
           "patterns": [
@@ -1279,7 +1279,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.pip",
           "patterns": [
@@ -1323,7 +1323,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.requirements",
           "patterns": [
@@ -1367,7 +1367,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.powerfx",
           "patterns": [
@@ -1411,7 +1411,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.powershell",
           "patterns": [
@@ -1455,7 +1455,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.properties",
           "patterns": [
@@ -1499,7 +1499,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.python",
           "patterns": [
@@ -1543,7 +1543,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.py",
           "patterns": [
@@ -1587,7 +1587,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.r",
           "patterns": [
@@ -1631,7 +1631,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.regex",
           "patterns": [
@@ -1675,7 +1675,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.ruby",
           "patterns": [
@@ -1719,7 +1719,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.rust",
           "patterns": [
@@ -1763,7 +1763,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.scss",
           "patterns": [
@@ -1807,7 +1807,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.shaderlab",
           "patterns": [
@@ -1851,7 +1851,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.shell",
           "patterns": [
@@ -1895,7 +1895,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.slim",
           "patterns": [
@@ -1939,7 +1939,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.sql",
           "patterns": [
@@ -1983,7 +1983,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.swift",
           "patterns": [
@@ -2027,7 +2027,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.typescript",
           "patterns": [
@@ -2071,7 +2071,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.ts",
           "patterns": [
@@ -2115,7 +2115,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.tsx",
           "patterns": [
@@ -2159,7 +2159,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.xml",
           "patterns": [
@@ -2203,7 +2203,7 @@
       "end": "^(?=\\S)|(?!\\G)",
       "patterns": [
         {
-          "begin": "^([ ]+)(?! )",
+          "begin": "(?>^|\\G)([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
           "name": "meta.embedded.inline.yaml",
           "patterns": [

--- a/syntaxes/injection.json
+++ b/syntaxes/injection.json
@@ -180,6 +180,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.c",
           "patterns": [
             {
@@ -224,6 +225,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.clojure",
           "patterns": [
             {
@@ -268,6 +270,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.coffee",
           "patterns": [
             {
@@ -312,6 +315,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.cpp",
           "patterns": [
             {
@@ -356,6 +360,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.c\\+\\+",
           "patterns": [
             {
@@ -400,6 +405,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.csharp",
           "patterns": [
             {
@@ -444,6 +450,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.css",
           "patterns": [
             {
@@ -488,6 +495,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.diff",
           "patterns": [
             {
@@ -532,6 +540,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.dockerfile",
           "patterns": [
             {
@@ -576,6 +585,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.dosbatch",
           "patterns": [
             {
@@ -620,6 +630,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.fsharp",
           "patterns": [
             {
@@ -664,6 +675,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.go",
           "patterns": [
             {
@@ -708,6 +720,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.groovy",
           "patterns": [
             {
@@ -752,6 +765,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.html",
           "patterns": [
             {
@@ -796,6 +810,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.java",
           "patterns": [
             {
@@ -840,6 +855,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.javascript",
           "patterns": [
             {
@@ -884,6 +900,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.js",
           "patterns": [
             {
@@ -928,6 +945,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.json",
           "patterns": [
             {
@@ -972,6 +990,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.tex",
           "patterns": [
             {
@@ -1016,6 +1035,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.latex",
           "patterns": [
             {
@@ -1060,6 +1080,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.lua",
           "patterns": [
             {
@@ -1104,6 +1125,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.makefile",
           "patterns": [
             {
@@ -1148,6 +1170,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.markdown",
           "patterns": [
             {
@@ -1192,6 +1215,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.objc",
           "patterns": [
             {
@@ -1236,6 +1260,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.perl",
           "patterns": [
             {
@@ -1280,6 +1305,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.pip",
           "patterns": [
             {
@@ -1324,6 +1350,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.requirements",
           "patterns": [
             {
@@ -1368,6 +1395,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.powerfx",
           "patterns": [
             {
@@ -1412,6 +1440,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.powershell",
           "patterns": [
             {
@@ -1456,6 +1485,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.properties",
           "patterns": [
             {
@@ -1500,6 +1530,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.python",
           "patterns": [
             {
@@ -1544,6 +1575,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.py",
           "patterns": [
             {
@@ -1588,6 +1620,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.r",
           "patterns": [
             {
@@ -1632,6 +1665,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.regex",
           "patterns": [
             {
@@ -1676,6 +1710,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.ruby",
           "patterns": [
             {
@@ -1720,6 +1755,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.rust",
           "patterns": [
             {
@@ -1764,6 +1800,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.scss",
           "patterns": [
             {
@@ -1808,6 +1845,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.shaderlab",
           "patterns": [
             {
@@ -1852,6 +1890,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.shell",
           "patterns": [
             {
@@ -1896,6 +1935,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.slim",
           "patterns": [
             {
@@ -1940,6 +1980,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.sql",
           "patterns": [
             {
@@ -1984,6 +2025,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.swift",
           "patterns": [
             {
@@ -2028,6 +2070,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.typescript",
           "patterns": [
             {
@@ -2072,6 +2115,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.ts",
           "patterns": [
             {
@@ -2116,6 +2160,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.tsx",
           "patterns": [
             {
@@ -2160,6 +2205,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.xml",
           "patterns": [
             {
@@ -2204,6 +2250,7 @@
         {
           "begin": "^([ ]+)(?! )",
           "end": "^(?!\\1|\\s*$)",
+          "while": "\\1",
           "name": "meta.embedded.inline.yaml",
           "patterns": [
             {


### PR DESCRIPTION
Fixes #13

Adds:
- `stripIndent` language config option
- better language config validation