### PR TITLE
Add examples and outbound links to "Extension Settings" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,16 @@ None
 | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `yaml-embedded-languages.include` | An object where the key defines the language identifier with regex and the value specifies the language TextMate scope name. By default the language identifier will be used as the language name. To change this, the value can be specified as an object with properties including `name`, `scopeName` (required), and `stripIndent`. Hover over these in VS Code to find out more. |
 
+You can find the TextMate scope name for a given language by following the [VS Code Docs here](https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide#scope-inspector)
+
+Basic Example:
+Suppose you have a plugin that provides `nginx` as an editor language, it's TextMate scope name would be `source.nginx`. If you wanted that language to be used when a the first line of a language block is `#nginx` your settings would look like this.
+```json
+  "yaml-embedded-languages.include": {
+    "nginx": "source.nginx"
+  },
+```
+
 ## Known Issues
 
 See [Issues](https://github.com/harrydowning/vscode-yaml-embedded-languages/issues)


### PR DESCRIPTION
* Adds language extension example for NGINX which would be a common language to embedded in YAML for K8s users (configmaps are widely used for NGINX containers and ingress controllers)

* Add outbound link to VS Code docs re: IDing TextMate scope